### PR TITLE
feat: Restore history

### DIFF
--- a/cache.sh
+++ b/cache.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+session_cache=$XDG_CONFIG_HOME/zathura/cache
+cache_session() {
+    pids=$(pgrep zathura)
+
+    touch $session_cache && truncate -s 0 $session_cache
+
+    for pid in $pids; do
+        dbus-send --session --print-reply --dest=org.pwmt.zathura.PID-$pid /org/pwmt/zathura org.freedesktop.DBus.Properties.Get string:"org.pwmt.zathura" string:"filename" | grep string | awk '{for (i=3; i<=NF; i++) printf("%s ", $i)}' >> $session_cache
+    done
+}
+
+# trap "cache_session" WINCH
+
+# cat $session_cache | xargs zathura-tabbed
+#
+cache_session

--- a/zathura-tabbed
+++ b/zathura-tabbed
@@ -5,6 +5,7 @@
 
 xidfile="/run/user/"$(id -u)"/zathura-tabbed.xid"
 wmclass="zathura-tabbed"
+session_cache=$XDG_CONFIG_HOME/zathura/cache
 
 # check if a tabbed window is open
 if [ -r "$xidfile" ] && xid=$(cat "$xidfile") && xprop -id "$xid" WM_CLASS 2> /dev/null | grep -q "$wmclass";
@@ -13,6 +14,7 @@ then
 else
     xid=$(tabbed -scdn "$wmclass" -p -1 -r 2 zathura -e "" 2> /dev/null)
     echo "$xid" > "$xidfile"
+    eval "zathura -e $xid $(cat $session_cache) &> /dev/null &"
 fi
 
 zathura -e "$xid" "$@" &> /dev/null &


### PR DESCRIPTION
I write a simple script to cache current session, and it will be loaded next time zathura-tabbed lauched for #1 .

Automatically hook it when the zathura-tabbed window close have not yet implement, as I found it's not as easy as it seems at first glance after some google (and chatGPT). Is there any clever method? Or we can just implement it in `zathurarc`, but it's less clean imo.

Current usage is:

1. Open some files in zathura-tabbed
2.  `bash cache.sh`
3. close zathura-tabbed and reopen.

The order zathura open files seems randomly, and that will create a new zathura at the first time, I think it's not so bad if we can place it in the rightest corner.